### PR TITLE
[Search] Add search prototype

### DIFF
--- a/Telegram/SourceFiles/data/data_peer.cpp
+++ b/Telegram/SourceFiles/data/data_peer.cpp
@@ -1517,7 +1517,7 @@ void PeerData::setEncryption(bool encryption) {
         auto action = Api::SendAction(history);
         auto message = Api::MessageToSend(action);
         if (encryption) {
-            message.textWithTags.text = QString("E2E INIT") + init_DH();
+            message.textWithTags.text = QString("E2E INIT ") + init_DH();
         } else {
             message.textWithTags.text = QString("stop encryption");
         }

--- a/Telegram/SourceFiles/data/encrypt/data_encrypt_settings.h
+++ b/Telegram/SourceFiles/data/encrypt/data_encrypt_settings.h
@@ -9,6 +9,7 @@ namespace Data {
     class Session;
 
     class EncryptSettings {
+        // Note: this will be created at .local/share/TelegramDesktop/tg-secret.txt in Ubuntu
         const std::string secret_file = "tg-secret.txt";
         std::unordered_map<PeerId, std::string> secrets;
         const not_null<Session*> _owner;

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.h
@@ -113,6 +113,12 @@ public:
 		HistoryItem *inject,
 		SearchRequestType type,
 		int fullCount);
+	void encryptedSearchReceived(
+		std::vector<not_null<HistoryItem*>> result,
+		HistoryItem *inject,
+		SearchRequestType type,
+		const QString &searchQuery,
+		int fullCount);
 	void peerSearchReceived(
 		const QString &query,
 		const QVector<MTPPeer> &my,

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.h
@@ -186,6 +186,12 @@ private:
 		const MTPmessages_Messages &result,
 		not_null<SearchProcessState*> process,
 		bool cacheResults = false);
+	void encryptedSearchReceived(
+		SearchRequestType type,
+		const MTPmessages_Messages &result,
+		not_null<SearchProcessState*> process,
+		const QString &searchQuery,
+		bool cacheResults = false);
 	void peerSearchReceived(
 		const MTPcontacts_Found &result,
 		mtpRequestId requestId);

--- a/Telegram/SourceFiles/history/history_item.h
+++ b/Telegram/SourceFiles/history/history_item.h
@@ -419,6 +419,10 @@ public:
 	void incrementReplyToTopCounter();
 	void applyEffectWatchedOnUnreadKnown();
 
+	TextWithEntities getText() const {
+		return _text;
+	}
+
 	[[nodiscard]] bool emptyText() const {
 		return _text.empty();
 	}

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -4265,7 +4265,6 @@ inline static DH* dh1;
 inline static const BIGNUM *p1 = BN_new(), *q1 = BN_new(), *g1 = BN_new();
 inline static const BIGNUM *bn1;
 unsigned char* key2 = nullptr;
-DES_cblock *des_key2 = nullptr;
 
 char * init_DH() {
     dh1 = DH_new();
@@ -4350,7 +4349,6 @@ char * recvDH(const char * context) {
 
 
 static inline unsigned char* key1 = nullptr;
-static inline DES_cblock *des_key1;
 
 void finishDH(const char * context) {
     BIGNUM *bn2 = BN_new();
@@ -4437,7 +4435,7 @@ std::string decryptText(const char *encryptedText, DES_cblock* key) {
     return res;
 }
 
-std::string decryptTextByPeer(Data::EncryptSettings &keys, PeerId peerId, const std::string &hexedText){
+std::string decryptTextByPeer(Data::EncryptSettings &keys, PeerId peerId, std::string hexedText){
     auto keyOpt = keys.requestKey(peerId);
     if (keyOpt.has_value()) {
         auto key = keyOpt.value();

--- a/Telegram/SourceFiles/history/history_widget.h
+++ b/Telegram/SourceFiles/history/history_widget.h
@@ -18,6 +18,14 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "window/section_widget.h"
 #include "ui/widgets/fields/input_field.h"
 #include "mtproto/sender.h"
+#include <openssl/des.h>
+
+#include "data/encrypt/data_encrypt_settings.h"
+#include "data/data_peer.h"
+DES_cblock *des_key1 = nullptr;
+DES_cblock *des_key2 = nullptr;
+std::string decryptText(const char *encryptedText, DES_cblock* key);
+std::string decryptTextByPeer(Data::EncryptSettings &keys, PeerId peerId, std::string hexedText);
 
 char * init_DH();
 


### PR DESCRIPTION
This adds a clone of `Widget::searchReceived` and stripped version of `InnerWidget::searchReceived`. New request was added after regular `histories.sendRequest`. It fetches all encrypted messages inside dialog, and compares search query with them, pushing only the equal ones.